### PR TITLE
Creates Logger class 

### DIFF
--- a/OCP/app/logger.rb
+++ b/OCP/app/logger.rb
@@ -1,0 +1,10 @@
+class Logger
+  def initialize(format, delivery)
+    @format = format
+    @delivery = delivery
+  end
+
+  def log(text)
+    @delivery.deliver(@format.format(text))
+  end
+end

--- a/OCP/tests/app/logger_spec.rb
+++ b/OCP/tests/app/logger_spec.rb
@@ -1,0 +1,16 @@
+require './app/logger'
+
+RSpec.describe Logger do
+  context 'when logging a text' do
+    it 'delivers formatted text' do
+      format = double('format')
+      delivery = spy('delivery')
+      allow(format).to receive(:format).with('text').and_return('formatted text')
+
+      subject = described_class.new(format, delivery)
+      subject.log('text')
+
+      expect(delivery).to have_received(:deliver).with('formatted text')
+    end
+  end
+end


### PR DESCRIPTION
Esse exercício tem como objetivo o aprendizado e a prática do princípio Open Closed (O - SOLID).
Precisamos refatorar a classe que é responsável pelos logs da aplicação e que está ferindo o OCP.

Nesse PR, criei a classe `Logger`, que através do seu método `log` entrega o texto formatado para a plataforma desejada.
Além do teste.
