### PR TITLE
Creates logger without formatting class

### DIFF
--- a/OCP/app/logger_without_formatting.rb
+++ b/OCP/app/logger_without_formatting.rb
@@ -1,0 +1,5 @@
+class LoggerWithoutFormatting
+  def format(text)
+    text
+  end
+end

--- a/OCP/tests/app/logger_without_formatting_spec.rb
+++ b/OCP/tests/app/logger_without_formatting_spec.rb
@@ -1,0 +1,13 @@
+require './app/logger_without_formatting'
+
+RSpec.describe LoggerWithoutFormatting do
+  context 'when receiving a text' do
+    it 'returns non formatted text' do
+      text = 'Olá, mundo.'
+
+      subject = described_class.new.format(text)
+
+      expect(subject).to eq(text)
+    end
+  end
+end


### PR DESCRIPTION
Esse exercício tem como objetivo o aprendizado e a prática do princípio Open Closed (O - SOLID).
Precisamos refatorar a classe que é responsável pelos logs da aplicação e que está ferindo o OCP.

Nesse PR, criei a classe `LoggerWithoutFormatting`, onde seu método `format` não faz nada com o texto recebido, apenas o retorna sem formatação.
Além do teste.