### PR TITLE
Refactors classes to implement Liskov Substitution Principle

### DIFF
--- a/LSP/analysis_script.rb
+++ b/LSP/analysis_script.rb
@@ -8,8 +8,6 @@ second_application = Application.new("Luana")
 third_application = Application.new("Lucas")
 applications = [first_application, second_application, third_application]
 
-
-
 katniss_everdeen = Analyst.new("Katniss Everdeen")
 aemon_targaryen = Analyst.new("Aemon Targaryen")
 doctor_strange = AutomaticDecisionAnalyst.new("Doctor Strange")

--- a/LSP/app/application.rb
+++ b/LSP/app/application.rb
@@ -1,5 +1,6 @@
 class Application
   attr_accessor :customer_name
+
   def initialize(customer_name)
     @customer_name = customer_name
   end

--- a/LSP/app/automatic_decision_analyst.rb
+++ b/LSP/app/automatic_decision_analyst.rb
@@ -1,11 +1,22 @@
 require_relative 'analyst'
 
 class AutomaticDecisionAnalyst < Analyst
-  def analyse(application, reject)
-    if reject
+  def initialize(name, random = Random::DEFAULT)
+    @name = name
+    @random = random
+  end
+
+  def analyse(application)
+    if rejected?
       puts "#{name} rejected #{application.customer_name}'s application."
     else
       puts "#{name} approved #{application.customer_name}'s application!"
     end
+  end
+
+  private
+
+  def rejected?
+    [true, false].sample(random: @random)
   end
 end

--- a/LSP/app/credit_analysis.rb
+++ b/LSP/app/credit_analysis.rb
@@ -9,12 +9,7 @@ class CreditAnalysis
   def analyse_all_applications
     @analysts.each do |analyst|
       @applications.each do |application|
-        if analyst.class == AutomaticDecisionAnalyst
-          reject = [true, false].sample
-          analyst.analyse(application, reject)
-        else
-          analyst.analyse(application)
-        end
+        analyst.analyse(application)
       end
     end
   end

--- a/LSP/tests/automatic_decision_analyst_spec.rb
+++ b/LSP/tests/automatic_decision_analyst_spec.rb
@@ -7,20 +7,20 @@ RSpec.describe AutomaticDecisionAnalyst do
         application = double('Application', customer_name: 'Zé')
         name = 'Natália'
 
-        subject = described_class.new(name)
+        subject = described_class.new(name, Random.new(1))
 
-        result = "#{name} approved #{application.customer_name}'s application!\n"
-        expect { subject.analyse(application, true) }.to output(result).to_stdout
+        result =  "#{name} approved #{application.customer_name}'s application!\n"
+        expect { subject.analyse(application) }.to output(result).to_stdout
       end
 
       it 'returns that the application is rejected' do
         application = double('Application', customer_name: 'Zé')
         name = 'Natália'
 
-        subject = described_class.new(name)
+        subject = described_class.new(name, Random.new(0))
 
-        result = "#{name} rejected #{application.customer_name}'s application.\n"
-        expect { subject.analyse(application, false) }.to output(result).to_stdout
+        result =  "#{name} rejected #{application.customer_name}'s application.\n"
+        expect { subject.analyse(application) }.to output(result).to_stdout
       end
     end
   end

--- a/LSP/tests/automatic_decision_analyst_spec.rb
+++ b/LSP/tests/automatic_decision_analyst_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AutomaticDecisionAnalyst do
 
         subject = described_class.new(name, Random.new(1))
 
-        result =  "#{name} approved #{application.customer_name}'s application!\n"
+        result = "#{name} approved #{application.customer_name}'s application!\n"
         expect { subject.analyse(application) }.to output(result).to_stdout
       end
 
@@ -19,7 +19,7 @@ RSpec.describe AutomaticDecisionAnalyst do
 
         subject = described_class.new(name, Random.new(0))
 
-        result =  "#{name} rejected #{application.customer_name}'s application.\n"
+        result = "#{name} rejected #{application.customer_name}'s application.\n"
         expect { subject.analyse(application) }.to output(result).to_stdout
       end
     end

--- a/LSP/tests/credit_analysis_spec.rb
+++ b/LSP/tests/credit_analysis_spec.rb
@@ -1,32 +1,15 @@
 require './app/credit_analysis'
-require './app/analyst'
-require './app/automatic_decision_analyst'
 
 RSpec.describe CreditAnalysis do
   context 'when analysing an application' do
-    context 'and analyst is an automatic analyst' do
-      xit 'automatically analyses the application' do
-        automatic_analyst = spy(AutomaticDecisionAnalyst)
-        application = double('Application', customer_name: 'Natália')
-        reject = true
+    it 'calls the analyst to analyse the application' do
+      analyst = spy('Analyst')
+      application = double('Application')
 
-        subject = described_class.new([automatic_analyst], [application])
-        subject.analyse_all_applications
+      subject = described_class.new([analyst], [application])
+      subject.analyse_all_applications
 
-        expect(automatic_analyst).to have_received(:analyse).with(application, reject)
-      end
-    end
-
-    context 'and analyst is not an automatic analyst' do
-      it 'calls the analyst to analyse the application' do
-        analyst = instance_spy('Analyst')
-        application = double('Application')
-
-        subject = described_class.new([analyst], [application])
-        subject.analyse_all_applications
-
-        expect(analyst).to have_received(:analyse).with(application)
-      end
+      expect(analyst).to have_received(:analyse).with(application)
     end
   end
 end


### PR DESCRIPTION
Esse exercício tem como objetivo o aprendizado e a prática de programação orientada a objetos, mais especificamente do princípio Liskov Substitution (L - SOLID).

Precisamos refatorar um código base fornecido previamente (implementação atual que está em produção, na branch `main`) e que está ferindo o LSP.

Nesse PR, extraí a tomada de decisão sobre uma análise automática ser aprovada ou rejeitada para a classe que faz análise automática (`AutomaticDecisionAnalyst`). Com isso, pude retirar o parâmentro  `reject` do método `analyse` dessa classe, fazendo com que tanto a classe mãe (`Analyst`), como a classe filha (`AutomaticDecisionAnalyst`) mantivessem o método `analyse` com a mesma assinatura e, desse modo, tanto o método de uma como da outra pode ser usado sem problemas pela classe `CreditAnalysis`.

[Link da História](https://github.com/users/nataliakikuchi/projects/1#card-52437643)